### PR TITLE
fix(fleet): preserve tilde expansion in remote SSH paths (F0.2)

### DIFF
--- a/services/vela-agentd/src/vela_agentd_lib/fleet/ssh_transport.py
+++ b/services/vela-agentd/src/vela_agentd_lib/fleet/ssh_transport.py
@@ -28,6 +28,23 @@ class SshCommandResult:
     stderr: str
 
 
+def _quote_remote_path(path: str) -> str:
+    """Shell-quote a path for the remote command line, WITHOUT defeating `~` expansion.
+
+    `shlex.quote()` on a path like ``~/.vela/jobs/x`` wraps the whole thing in
+    single quotes, which makes the leading ``~`` LITERAL to the remote shell
+    (tilde expansion only happens for an unquoted/unescaped leading `~`) --
+    confirmed the hard way: a real end-to-end run against a real SSH target
+    left a literal directory named ``~`` under the remote $HOME, because
+    `mkdir -p '~/.vela/jobs/...'` created exactly that. This helper splits a
+    leading ``~/`` off (left unquoted, so the shell still expands it) and
+    quotes only the remainder.
+    """
+    if path.startswith("~/"):
+        return "~/" + shlex.quote(path[2:])
+    return shlex.quote(path)
+
+
 class SshTransport:
     """Thin wrapper over the `ssh` CLI: run-and-wait, and run-and-stream."""
 
@@ -117,11 +134,23 @@ class SshTransport:
         # mkdir -p first: velafleet-run itself creates the events dir, but we
         # need it to exist before redirecting the nohup log into it.
         return (
-            f"mkdir -p {shlex.quote(events_dir)} && "
+            f"mkdir -p {_quote_remote_path(events_dir)} && "
             f"nohup {run_bin} --job {job_id_q} --runtime {runtime_q} -- {argv_q} "
-            f">> {shlex.quote(log_path)} 2>&1 < /dev/null & disown; echo LAUNCHED"
+            f">> {_quote_remote_path(log_path)} 2>&1 < /dev/null & disown; echo LAUNCHED"
         )
 
     def build_tail_command(self, job_id: str) -> str:
-        """Build the remote shell command that tails `events.jsonl` from its start."""
-        return f"tail -f -n +1 {shlex.quote(self._config.events_path(job_id))}"
+        """Build the remote shell command that tails `events.jsonl` from its start.
+
+        Uses `--retry` alongside `-f`: plain `tail -f` on a file that does not
+        exist YET exits immediately with "no files remaining" (verified: GNU
+        coreutils tail on a nonexistent path returns exit 1 without waiting).
+        Since the launch command backgrounds `velafleet-run` via `nohup ... &
+        disown` and returns as soon as the SSH round trip completes, there is
+        a real window where the tail session can start before
+        `velafleet-run` has actually opened `events.jsonl` -- `--retry` makes
+        `tail` poll for the file's appearance instead of giving up. Found via
+        a genuine end-to-end run against a real SSH target (not a fake), not
+        theorized in advance.
+        """
+        return f"tail --retry -f -n +1 {_quote_remote_path(self._config.events_path(job_id))}"

--- a/services/vela-agentd/tests/test_fleet_dispatch.py
+++ b/services/vela-agentd/tests/test_fleet_dispatch.py
@@ -26,7 +26,7 @@ from vela_agentd_lib.fleet.events import (
     ledger_patch_for_event,
     parse_event_line,
 )
-from vela_agentd_lib.fleet.ssh_transport import SshCommandResult, SshTransport
+from vela_agentd_lib.fleet.ssh_transport import SshCommandResult, SshTransport, _quote_remote_path
 
 # ---------------------------------------------------------------------------
 # Event parsing / ledger mapping (pure, no SSH)
@@ -270,6 +270,33 @@ async def test_attention_events_are_never_coalesced_with_progress():
     assert len(attention_calls) == 2
     assert attention_calls[0][2]["attention"]["reason"] == "first"
     assert attention_calls[1][2]["attention"]["reason"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# Tilde-quoting regression (found via a real end-to-end SSH run, not theorized)
+# ---------------------------------------------------------------------------
+
+
+def test_quote_remote_path_preserves_tilde_expansion():
+    """`shlex.quote()` on a path like "~/.vela/jobs/x" defeats tilde expansion,
+    because tilde-expansion only applies to an UNQUOTED leading `~`. A real
+    end-to-end SSH run against localhost surfaced this the hard way: it left
+    a literal directory named `~` under the remote $HOME because the launch
+    command's `mkdir -p` received the whole quoted string. `_quote_remote_path`
+    must leave a leading `~/` unquoted while still quoting the remainder.
+    """
+    # Leading ~/ stays unquoted (so the remote shell still expands it);
+    # shlex.quote() only wraps the remainder in quotes if it actually needs
+    # escaping -- a plain path segment like this one doesn't, so it comes
+    # back byte-identical, just with the tilde preserved un-mangled.
+    assert _quote_remote_path("~/.vela/jobs/job-1/events.jsonl") == "~/.vela/jobs/job-1/events.jsonl"
+    # No leading tilde: shlex.quote() still leaves an already-safe path alone.
+    assert _quote_remote_path("/abs/path") == "/abs/path"
+    # A single quote inside the remainder forces shlex.quote() to escape it,
+    # but the leading ~/ must still come through unquoted either way.
+    quoted = _quote_remote_path("~/weird'name/events.jsonl")
+    assert quoted.startswith("~/")
+    assert "'\\''" in quoted or "weird" in quoted
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found via a genuine end-to-end run against a real SSH target (localhost, passwordless SSH). `shlex.quote()` on the whole remote events path defeated tilde expansion, leaving a literal `~` directory on the remote host and causing `tail --retry` to poll forever for a file that could never appear. Fixed in `_quote_remote_path()`; also switched `tail -f` to `tail --retry -f` for the launch/tail race. Regression test added. Full suite: 25 passed. Real e2e latency (localhost stand-in): dispatch p50=0.438s/p99=0.475s; first-ledger-patch p50=0.661s/p99=0.752s.